### PR TITLE
Add version command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ target/
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
 
+.opencode
+
 # RustRover
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@ struct Cli {
 enum Commands {
     Install(InstallArgs),
     Init,
+    Version,
 }
 
 #[derive(Debug, Args)]
@@ -63,6 +64,9 @@ async fn main() {
             let path = pwd.to_str().unwrap();
 
             installer::init_fxpkg(path);
+        }
+        Commands::Version => {
+            println!("fxpkg version 0.1.0");
         }
     }
 }


### PR DESCRIPTION
## Summary
- Added a new `version` command to display the current CLI version
- Updated .gitignore to exclude .opencode directory

## Test plan
- Run `cargo run -- version` to verify the version command works correctly

🤖 Generated with opencode