### PR TITLE
feat: add resources directory validation for init and install commands

### DIFF
--- a/src/installer/mod.rs
+++ b/src/installer/mod.rs
@@ -56,6 +56,10 @@ pub fn init_fxpkg(working_dir: &str) {
         let mut file = std::io::BufWriter::new(file);
         file.write_all(stub_content.as_bytes())
             .expect("Failed to write to modules.json file");
+        
+        println!("Created modules.json file successfully.");
+    } else {
+        println!("modules.json file already exists.");
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ pub mod registry;
 
 use clap::{Args, Parser, Subcommand};
 use std::env;
+use std::path::Path;
 
 #[derive(Debug, Parser)]
 #[command(name = "fxpkg")]
@@ -44,6 +45,32 @@ struct InstallArgs {
     name: String,
 }
 
+fn find_resources_directory(current_path: &Path) -> Result<String, String> {
+    let mut path = current_path.to_path_buf();
+    
+    // Check if current directory is already "resources"
+    if path.file_name().and_then(|n| n.to_str()) == Some("resources") {
+        return Ok(path.to_string_lossy().to_string());
+    }
+    
+    // Traverse upwards to find "resources" directory
+    loop {
+        let resources_path = path.join("resources");
+        if resources_path.exists() && resources_path.is_dir() {
+            return Ok(resources_path.to_string_lossy().to_string());
+        }
+        
+        // Move to parent directory
+        if let Some(parent) = path.parent() {
+            path = parent.to_path_buf();
+        } else {
+            break;
+        }
+    }
+    
+    Err("Could not find 'resources' directory. Please run 'fxpkg init' from within or above a 'resources' directory.".to_string())
+}
+
 #[tokio::main]
 async fn main() {
     dotenv::dotenv().ok();
@@ -53,16 +80,30 @@ async fn main() {
 
     match args.commands {
         Commands::Install(package) => {
-            let mut pkg_installer = installer::PackageInstall::new();
-            pkg_installer
-                .install(pwd.to_str().unwrap(), &package.name)
-                .await;
+            match find_resources_directory(&pwd) {
+                Ok(resources_path) => {
+                    let mut pkg_installer = installer::PackageInstall::new();
+                    pkg_installer
+                        .install(&resources_path, &package.name)
+                        .await;
+                }
+                Err(error_msg) => {
+                    eprintln!("Error: {}", error_msg);
+                    std::process::exit(1);
+                }
+            }
         }
         Commands::Init => {
-            let pwd = env::current_dir().unwrap();
-            let path = pwd.to_str().unwrap();
-
-            installer::init_fxpkg(path);
+            match find_resources_directory(&pwd) {
+                Ok(resources_path) => {
+                    installer::init_fxpkg(&resources_path);
+                    println!("Initialized fxpkg in: {}", resources_path);
+                }
+                Err(error_msg) => {
+                    eprintln!("Error: {}", error_msg);
+                    std::process::exit(1);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR implements automatic resources directory detection and validation for both `init` and `install` commands, ensuring that `modules.json` is always created in the correct location.

## Key Changes

- Added `find_resources_directory()` function that traverses upward to find resources directory
- Updated both init and install commands to validate they operate within resources directory  
- Enhanced error handling with descriptive messages when resources directory not found
- Improved user feedback with clear success/status messages

## How It Works

The commands now work from:
- ✅ Within resources directory
- ✅ Subdirectories of resources (traverses upward)
- ✅ Parent directories containing resources (finds subdirectory)
- ❌ Unrelated directories (shows error and exits)

This ensures modules.json is always created in the correct resources directory regardless of where the user runs the command.